### PR TITLE
Deprecate get_pkgconfig_variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,9 +44,9 @@ executable('phosphor-srvcfg-manager',
         install_dir: get_option('bindir'))
 
 systemd = dependency('systemd')
-systemd_system_unit_dir = systemd.get_pkgconfig_variable(
-    'systemdsystemunitdir',
-    define_variable: ['prefix', get_option('prefix')])
+systemd_system_unit_dir = systemd.get_variable(
+    pkgconfig: 'systemdsystemunitdir',
+    pkgconfig_define: ['prefix', get_option('prefix')])
 
 configure_file(
     copy: true,


### PR DESCRIPTION
Since meson (>=0.56) the use of `get_pkgconfig_variable()` is deprecated
in favor of the more arbitrary `get_variable()`. See reference [1]
under: "Arbitrary variables from dependencies that can be found multiple
ways".

[1]: https://github.com/mesonbuild/meson/blob/master/docs/markdown/Dependencies.md

Signed-off-by: Patrik Tesarik <patrik.tesarik@rub.de>