### PR TITLE
Add subproject directory & wrapper files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,9 +26,9 @@ boost_args = ['-DBOOST_ALL_NO_LIB',
 
 deps = [dependency('boost'),
         dependency('boost', modules : ['coroutine']),
-        dependency('phosphor-dbus-interfaces'),
-        dependency('phosphor-logging'),
-        dependency('sdbusplus'),
+        dependency('phosphor-dbus-interfaces', fallback: ['phosphor-dbus-interfaces', 'phosphor_dbus_interfaces_dep']),
+        dependency('phosphor-logging', fallback: ['phosphor-logging', 'phosphor_logging_dep']),
+        dependency('sdbusplus', fallback: ['sdbusplus', 'sdbusplus_dep']),
         dependency('systemd'),
 ]
 

--- a/subprojects/phosphor-dbus-interfaces.wrap
+++ b/subprojects/phosphor-dbus-interfaces.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-dbus-interfaces.git
+revision = HEAD

--- a/subprojects/phosphor-logging.wrap
+++ b/subprojects/phosphor-logging.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-logging.git
+revision = HEAD

--- a/subprojects/sdbusplus.wrap
+++ b/subprojects/sdbusplus.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/sdbusplus.git
+revision = HEAD


### PR DESCRIPTION
This commit enables the isolated build of this repository with meson.
This commit was made possible by Patrick's [blog post][].

[blog post]: http://www.stwcx.xyz/blog/2021/04/18/meson-subprojects.html

Signed-off-by: Patrik Tesarik <patrik.tesarik@rub.de>

Building standalone with `meson setup builddir && ninja -C builddir` worked up to the point when `phosphor-logging` raised an [error](https://github.com/openbmc/phosphor-logging/issues/22). So I cannot state that it is fully tested, but setup up the `builddir` correctly should've been half the way. 

